### PR TITLE
remove ez_setup call from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,6 @@ For older changes, see
 
 """
 
-from ez_setup import use_setuptools
-use_setuptools()
-
 from setuptools import setup, find_packages
 
 doclines = __doc__.splitlines()


### PR DESCRIPTION
removing unnecessary `ez_setup` import
addresses issue #2 