### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/vobject/base.py
+++ b/vobject/base.py
@@ -182,10 +182,10 @@ class VBase(object):
             behavior = self.behavior
         
         if behavior:
-            if DEBUG: logger.debug("serializing %s with behavior" % self.name)
+            if DEBUG: logger.debug("serializing {0!s} with behavior".format(self.name))
             return behavior.serialize(self, buf, lineLength, validate)
         else:
-            if DEBUG: logger.debug("serializing %s without behavior" % self.name)
+            if DEBUG: logger.debug("serializing {0!s} without behavior".format(self.name))
             return defaultSerialize(self, buf, lineLength)
 
 def ascii(s):
@@ -635,8 +635,7 @@ class VObjectError(Exception):
             self.lineNumber = lineNumber
     def __str__(self):
         if hasattr(self, 'lineNumber'):
-            return "At line %s: %s" % \
-                   (self.lineNumber, self.msg)
+            return "At line {0!s}: {1!s}".format(self.lineNumber, self.msg)
         else:
             return repr(self.msg)
 
@@ -666,41 +665,41 @@ patterns['qsafe_char'] = '[^"]'
 # param_value is any number of safe_chars or any number of qsaf_chars surrounded
 # by double quotes.
 
-patterns['param_value'] = ' "%(qsafe_char)s * " | %(safe_char)s * ' % patterns
+patterns['param_value'] = ' "{qsafe_char!s} * " | {safe_char!s} * '.format(**patterns)
 
 
 # get a tuple of two elements, one will be empty, the other will have the value
 patterns['param_value_grouped'] = """
-" ( %(qsafe_char)s * )" | ( %(safe_char)s + )
-""" % patterns
+" ( {qsafe_char!s} * )" | ( {safe_char!s} + )
+""".format(**patterns)
 
 # get a parameter and its values, without any saved groups
 patterns['param'] = r"""
-; (?: %(name)s )                     # parameter name
+; (?: {name!s} )                     # parameter name
 (?:
-    (?: = (?: %(param_value)s ) )?   # 0 or more parameter values, multiple 
-    (?: , (?: %(param_value)s ) )*   # parameters are comma separated
+    (?: = (?: {param_value!s} ) )?   # 0 or more parameter values, multiple 
+    (?: , (?: {param_value!s} ) )*   # parameters are comma separated
 )*                         
-""" % patterns
+""".format(**patterns)
 
 # get a parameter, saving groups for name and value (value still needs parsing)
 patterns['params_grouped'] = r"""
-; ( %(name)s )
+; ( {name!s} )
 
 (?: =
     (
-        (?:   (?: %(param_value)s ) )?   # 0 or more parameter values, multiple 
-        (?: , (?: %(param_value)s ) )*   # parameters are comma separated
+        (?:   (?: {param_value!s} ) )?   # 0 or more parameter values, multiple 
+        (?: , (?: {param_value!s} ) )*   # parameters are comma separated
     )
 )?
-""" % patterns
+""".format(**patterns)
 
 # get a full content line, break it up into group, name, parameters, and value
 patterns['line'] = r"""
-^ ((?P<group> %(name)s)\.)?(?P<name> %(name)s) # name group
-  (?P<params> (?: %(param)s )* )               # params group (may be empty)
+^ ((?P<group> {name!s})\.)?(?P<name> {name!s}) # name group
+  (?P<params> (?: {param!s} )* )               # params group (may be empty)
 : (?P<value> .* )$                             # value group
-""" % patterns
+""".format(**patterns)
 
 ' "%(qsafe_char)s*" | %(safe_char)s* '
 
@@ -755,7 +754,7 @@ def parseLine(line, lineNumber = None):
     
     match = line_re.match(line)
     if match is None:
-        raise ParseError("Failed to parse line: %s" % line, lineNumber)
+        raise ParseError("Failed to parse line: {0!s}".format(line), lineNumber)
     # Underscores are replaced with dash to work around Lotus Notes
     return (match.group('name').replace('_','-'),                                 
             parseParams(match.group('params')),
@@ -764,15 +763,15 @@ def parseLine(line, lineNumber = None):
 # logical line regular expressions
 
 patterns['lineend'] = r'(?:\r\n|\r|\n|$)'
-patterns['wrap'] = r'%(lineend)s [\t ]' % patterns
+patterns['wrap'] = r'{lineend!s} [\t ]'.format(**patterns)
 patterns['logicallines'] = r"""
 (
-   (?: [^\r\n] | %(wrap)s )*
-   %(lineend)s
+   (?: [^\r\n] | {wrap!s} )*
+   {lineend!s}
 )
-""" % patterns
+""".format(**patterns)
 
-patterns['wraporend'] = r'(%(wrap)s | %(lineend)s )' % patterns
+patterns['wraporend'] = r'({wrap!s} | {lineend!s} )'.format(**patterns)
 
 wrap_re          = re.compile(patterns['wraporend'],    re.VERBOSE)
 logical_lines_re = re.compile(patterns['logicallines'], re.VERBOSE)
@@ -1043,8 +1042,8 @@ def readComponents(streamOrString, validate=False, transform=True,
                 stack.top().setProfile(vline.value)
             elif vline.name == "END":
                 if len(stack) == 0:
-                    err = "Attempted to end the %s component, \
-                           but it was never opened" % vline.value
+                    err = "Attempted to end the {0!s} component, \
+                           but it was never opened".format(vline.value)
                     raise ParseError(err, n)
                 if vline.value.upper() == stack.topName(): #START matches END
                     if len(stack) == 1:
@@ -1067,7 +1066,7 @@ def readComponents(streamOrString, validate=False, transform=True,
             if stack.topName() is None:
                 logger.warning("Top level component was never named")
             elif stack.top().useBegin:
-                raise ParseError("Component %s was never closed" % (stack.topName()), n)
+                raise ParseError("Component {0!s} was never closed".format((stack.topName())), n)
             yield stack.pop()
 
     except ParseError, e:
@@ -1122,7 +1121,7 @@ def newFromBehavior(name, id=None):
     name = name.upper()
     behavior = getBehavior(name, id)
     if behavior is None:
-        raise VObjectError("No behavior found named %s" % name)
+        raise VObjectError("No behavior found named {0!s}".format(name))
     if behavior.isComponent:
         obj = Component(name)
     else:

--- a/vobject/change_tz.py
+++ b/vobject/change_tz.py
@@ -36,18 +36,18 @@ def main():
             which = "only UTC"
         else:
             which = "all"
-        print "Converting %s events" % which
+        print "Converting {0!s} events".format(which)
         ics_file = args[0]
         if len(args) > 1:
             timezone = PyICU.ICUtzinfo.getInstance(args[1])
         else:
             timezone = PyICU.ICUtzinfo.default
-        print "... Reading %s" % ics_file
+        print "... Reading {0!s}".format(ics_file)
         cal = base.readOne(file(ics_file))
         change_tz(cal, timezone, PyICU.ICUtzinfo.default, utc_only)
 
         out_name = ics_file + '.converted'
-        print "... Writing %s" % out_name
+        print "... Writing {0!s}".format(out_name)
         out = file(out_name, 'wb')
         cal.serialize(out)
         print "Done"

--- a/vobject/hcalendar.py
+++ b/vobject/hcalendar.py
@@ -84,8 +84,7 @@ class HCalendar(VCalendar2_0):
                 #TODO: Handle non-datetime formats?
                 #TODO: Spec says we should handle when dtstart isn't included
                 
-                out('<abbr class="dtstart", title="%s">%s</abbr>\r\n' % 
-                     (dtstart.strftime(machine), dtstart.strftime(timeformat)))
+                out('<abbr class="dtstart", title="{0!s}">{1!s}</abbr>\r\n'.format(dtstart.strftime(machine), dtstart.strftime(timeformat)))
                 
                 # DTEND
                 dtend = event.getChildValue("dtend")
@@ -101,8 +100,7 @@ class HCalendar(VCalendar2_0):
                     if type(dtend) == date:
                         human = dtend - timedelta(days=1)
                         
-                    out('- <abbr class="dtend", title="%s">%s</abbr>\r\n' % 
-                     (dtend.strftime(machine), human.strftime(timeformat)))    
+                    out('- <abbr class="dtend", title="{0!s}">{1!s}</abbr>\r\n'.format(dtend.strftime(machine), human.strftime(timeformat)))    
 
             # LOCATION    
             location = event.getChildValue("location")

--- a/vobject/icalendar.py
+++ b/vobject/icalendar.py
@@ -258,8 +258,7 @@ class TimezoneComponent(Component):
                     endString = ";UNTIL="+ dateTimeToString(endDate)
                 else:
                     endString = ''
-                rulestring = "FREQ=YEARLY%s;BYMONTH=%s%s" % \
-                              (dayString, str(rule['month']), endString)
+                rulestring = "FREQ=YEARLY{0!s};BYMONTH={1!s}{2!s}".format(dayString, str(rule['month']), endString)
                 
                 comp.add('rrule').value = rulestring
 
@@ -294,7 +293,7 @@ class TimezoneComponent(Component):
                 if tzinfo.dst(dt) == notDST:
                     return toUnicode(tzinfo.tzname(dt))
         # there was no standard time in 2000!
-        raise VObjectError("Unable to guess TZID for tzinfo %s" % str(tzinfo))
+        raise VObjectError("Unable to guess TZID for tzinfo {0!s}".format(str(tzinfo)))
 
     def __str__(self):
         return "<VTIMEZONE | " + str(getattr(self, 'tzid', 'No TZID')) +">"
@@ -1616,7 +1615,7 @@ def stringToDateTime(s, tzinfo=None):
             if s[15] == 'Z':
                 tzinfo = utc
     except:
-        raise ParseError("'%s' is not a valid DATE-TIME" % s)
+        raise ParseError("'{0!s}' is not a valid DATE-TIME".format(s))
     return datetime.datetime(year, month, day, hour, minute, second, 0, tzinfo)
 
 
@@ -1690,7 +1689,7 @@ def stringToTextValues(s, listSeparator=',', charList=None, strict=False):
 
         else:
             state = "error"
-            error("error: unknown state: '%s' reached in %s" % (state, s))
+            error("error: unknown state: '{0!s}' reached in {1!s}".format(state, s))
 
 def stringToDurations(s, strict=False):
     """Returns list of timedelta objects."""
@@ -1748,8 +1747,8 @@ def stringToDurations(s, strict=False):
                 current = current + char   #update this part when updating "read field"
             else:
                 state = "error"
-                print "got unexpected character %s reading in duration: %s" % (char, s)
-                error("got unexpected character %s reading in duration: %s" % (char, s))
+                print "got unexpected character {0!s} reading in duration: {1!s}".format(char, s)
+                error("got unexpected character {0!s} reading in duration: {1!s}".format(char, s))
 
         elif state == "read field":
             if (char in string.digits):
@@ -1806,7 +1805,7 @@ def stringToDurations(s, strict=False):
 
         else:
             state = "error"
-            error("error: unknown state: '%s' reached in %s" % (state, s))
+            error("error: unknown state: '{0!s}' reached in {1!s}".format(state, s))
 
 def parseDtstart(contentline, allowSignatureMismatch=False):
     """Convert a contentline's value into a date or date-time.

--- a/vobject/ics_diff.py
+++ b/vobject/ics_diff.py
@@ -10,7 +10,7 @@ def getSortKey(component):
 
     def getSequence(component):
         sequence = component.getChildValue('sequence', 0)
-        return "%05d" % int(sequence)
+        return "{0:05d}".format(int(sequence))
     
     def getRecurrenceID(component):
         recurrence_id = component.getChildValue('recurrence_id', None)

--- a/vobject/vcard.py
+++ b/vobject/vcard.py
@@ -33,7 +33,7 @@ class Name(object):
         return ascii(out)
 
     def __repr__(self):
-        return "<Name: %s>" % self.__str__()
+        return "<Name: {0!s}>".format(self.__str__())
 
     def __eq__(self, other):
         try:
@@ -70,13 +70,13 @@ class Address(object):
     def __str__(self):
         lines = '\n'.join(self.toString(getattr(self, val)) for val in self.lines if getattr(self, val))
         one_line = tuple(self.toString(getattr(self, val), ' ') for val in self.one_line)
-        lines += "\n%s, %s %s" % one_line
+        lines += "\n{0!s}, {1!s} {2!s}".format(*one_line)
         if self.country:
             lines += '\n' + self.toString(self.country)
         return ascii(lines)
 
     def __repr__(self):
-        return "<Address: %s>" % repr(str(self))[1:-1]
+        return "<Address: {0!s}>".format(repr(str(self))[1:-1])
 
     def __eq__(self, other):
         try:
@@ -187,7 +187,7 @@ class Photo(VCardTextBehavior):
     description = 'Photograph'
     @classmethod
     def valueRepr( cls, line ):
-        return " (BINARY PHOTO DATA at 0x%s) " % id( line.value )
+        return " (BINARY PHOTO DATA at 0x{0!s}) ".format(id( line.value ))
 
     @classmethod
     def serialize(cls, obj, buf, lineLength, validate):

--- a/vobject/win32tz.py
+++ b/vobject/win32tz.py
@@ -69,7 +69,7 @@ class win32tz(datetime.tzinfo):
             else: return True
 
     def __repr__(self):
-        return "<win32tz - %s>" % self.data.display
+        return "<win32tz - {0!s}>".format(self.data.display)
 
 def pickNthWeekday(year, month, dayofweek, hour, minute, whichweek):
     """dayofweek == 0 means Sunday, whichweek > 4 means last instance"""


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:eventable:vobject?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:eventable:vobject?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)