### PR TITLE
The rule plus must be an integer

### DIFF
--- a/vobject/icalendar.py
+++ b/vobject/icalendar.py
@@ -210,7 +210,8 @@ class TimezoneComponent(Component):
                             'weekday' : transition.weekday(),
                             'hour'    : transition.hour,
                             'name'    : tzinfo.tzname(transition),
-                            'plus'    : (transition.day - 1)/ 7 + 1,  # nth week of the month
+                            'plus'    : int(
+                                (transition.day - 1)/ 7 + 1),  # nth week of the month
                             'minus'   : fromLastWeek(transition),  # nth from last week
                             'offset'  : tzinfo.utcoffset(transition),
                             'offsetfrom' : old_offset}


### PR DESCRIPTION
The root cause is simple:
in python 2:

    >>> 24/7
    3

while in python3

    >>> 24/7
    3.4285714285714284

So we just need to always convert to an int so that it works for both
py2 and py3.

Fixes https://github.com/dateutil/dateutil/issues/145
Fixes https://github.com/eventable/vobject/issues/10
Fixes https://github.com/eventable/vobject/pull/11