### PR TITLE
Better line folding for utf-8 strings

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -135,7 +135,8 @@ class TestCalendarSerializing(unittest.TestCase):
             "REQUEST-STATUS:5.1;Service unavailable"
         )
 
-    def test_unicode_multiline(self):
+    @staticmethod
+    def test_unicode_multiline():
         """
         Test multiline unicode characters
         """

--- a/tests.py
+++ b/tests.py
@@ -7,11 +7,12 @@ import dateutil
 import re
 import sys
 import unittest
+import json
 
 from dateutil.tz import tzutc
 from dateutil.rrule import rrule, rruleset, WEEKLY, MONTHLY
 
-from vobject import base
+from vobject import base, iCalendar
 from vobject import icalendar
 
 from vobject.base import __behaviorRegistry as behavior_registry
@@ -25,7 +26,7 @@ from vobject.icalendar import MultiDateBehavior, PeriodBehavior, \
 from vobject.icalendar import parseDtstart, stringToTextValues, \
     stringToPeriod, timedeltaToString
 
-two_hours  = datetime.timedelta(hours=2)
+two_hours = datetime.timedelta(hours=2)
 
 
 def get_test_file(path):
@@ -133,6 +134,21 @@ class TestCalendarSerializing(unittest.TestCase):
             request_status.serialize().strip(),
             "REQUEST-STATUS:5.1;Service unavailable"
         )
+
+    def test_unicode_multiline(self):
+        """
+        Test multiline unicode characters
+        """
+        cal = iCalendar()
+        cal.add('method').value = 'REQUEST'
+        cal.add('vevent')
+        cal.vevent.add('created').value = datetime.datetime.now()
+        cal.vevent.add('summary').value = 'Классное событие'
+        cal.vevent.add('description').value = ('Классное событие Классное событие Классное событие Классное событие '
+                                               'Классное событие Классsdssdное событие')
+
+        # json tries to encode as utf-8 and it would break if some chars could not be encoded
+        json.dumps(cal.serialize())
 
     @staticmethod
     def test_ical_to_hcal():

--- a/vobject/base.py
+++ b/vobject/base.py
@@ -34,6 +34,30 @@ except NameError:
         """
         return s
 
+if not isinstance(b'', type('')):
+    unicode_type = str
+else:
+    unicode_type = unicode  # noqa
+
+
+def to_unicode(value):
+    """Converts a string argument to a unicode string.
+
+    If the argument is already a unicode string, it is returned
+    unchanged.  Otherwise it must be a byte string and is decoded as utf8.
+    """
+    if isinstance(value, unicode_type):
+        return value
+
+    return value.decode('utf-8')
+
+
+def to_basestring(s):
+    if isinstance(s, bytes):
+        return s
+
+    return s.encode('utf-8')
+
 # ------------------------------------ Logging ---------------------------------
 logger = logging.getLogger(__name__)
 if not logging.getLogger().handlers:
@@ -914,10 +938,11 @@ def foldOneLine(outbuf, input, lineLength = 75):
         start = 0
         written = 0
         counter = 0  # counts line size in bytes
-        decoded = input.decode('utf-8')
-        while written < len(input):
+        decoded = to_unicode(input)
+        length = len(to_basestring(input))
+        while written < length:
             s = decoded[start]  # take one char
-            size = len(s.encode('utf-8'))  # calculate it's size in bytes
+            size = len(to_basestring(s))  # calculate it's size in bytes
             if counter + size > lineLength:
                 try:
                     outbuf.write(bytes("\r\n ", 'UTF-8'))
@@ -927,9 +952,9 @@ def foldOneLine(outbuf, input, lineLength = 75):
 
                 counter = 1  # one for space
 
-            try:
-                outbuf.write(bytes(s.encode('utf-8'), 'UTF-8'))
-            except:
+            if str is unicode_type:
+                outbuf.write(to_unicode(s))
+            else:
                 # fall back on py2 syntax
                 outbuf.write(s.encode('utf-8'))
 

--- a/vobject/base.py
+++ b/vobject/base.py
@@ -53,6 +53,11 @@ def to_unicode(value):
 
 
 def to_basestring(s):
+    """Converts a string argument to a byte string.
+
+    If the argument is already a byte string, it is returned unchanged.
+    Otherwise it must be a unicode string and is encoded as utf8.
+    """
     if isinstance(s, bytes):
         return s
 

--- a/vobject/base.py
+++ b/vobject/base.py
@@ -913,28 +913,29 @@ def foldOneLine(outbuf, input, lineLength = 75):
         # Look for valid utf8 range and write that out
         start = 0
         written = 0
+        counter = 0  # counts line size in bytes
+        decoded = input.decode('utf-8')
         while written < len(input):
-            # Start max length -1 chars on from where we are
-            offset = start + lineLength - 1
-            if offset >= len(input):
-                line = input[start:]
+            s = decoded[start]  # take one char
+            size = len(s.encode('utf-8'))  # calculate it's size in bytes
+            if counter + size > lineLength:
                 try:
-                    outbuf.write(bytes(line, 'UTF-8'))
-                except Exception:
-                    # fall back on py2 syntax
-                    outbuf.write(line)
-                written = len(input)
-            else:
-                line = input[start:offset]
-                try:
-                    outbuf.write(bytes(line, 'UTF-8'))
                     outbuf.write(bytes("\r\n ", 'UTF-8'))
                 except Exception:
                     # fall back on py2 syntax
-                    outbuf.write(line)
                     outbuf.write("\r\n ")
-                written += offset - start
-                start = offset
+
+                counter = 1  # one for space
+
+            try:
+                outbuf.write(bytes(s.encode('utf-8'), 'UTF-8'))
+            except:
+                # fall back on py2 syntax
+                outbuf.write(s.encode('utf-8'))
+
+            written += size
+            counter += size
+            start += 1
     try:
         outbuf.write(bytes("\r\n", 'UTF-8'))
     except Exception:


### PR DESCRIPTION
Hello!

I have mentioned that sometimes serializing of the event doesn't work with long unicode strings (which needs to be folded) and mentioned that it splits unicode character (two bytes) and this break the result (it becomes not a valid utf8 string).

I have done some changes to calculate split depend on unicode character size.