### PR TITLE
Fix use of __doc__ in setup.py for -OO mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ For older changes, see
 
 from setuptools import setup, find_packages
 
-doclines = __doc__.splitlines()
+doclines = (__doc__ or '').splitlines()
 
 setup(name = "vobject",
       version = "0.9.2",


### PR DESCRIPTION
Currently setup will fail when using `pip install vobject` if the `-OO` flag is used (also enabled via `PYTHONOPTIMIZE=2`) because docstrings are stripped (which is the point of that mode).

Very minor change that allows the docstring to be missing for this case and install to work as expected.