### PR TITLE
Revert "use correct encoding and codecs-module (available in python2 …

### DIFF
--- a/vobject/base.py
+++ b/vobject/base.py
@@ -7,7 +7,7 @@ import logging
 import re
 import six
 import sys
-import codecs
+import quopri
 
 # ------------------------------------ Python 2/3 compatibility challenges  ----
 # Python 3 no longer has a basestring type, so....
@@ -334,7 +334,7 @@ class ContentLine(VBase):
             qp = True
             self.singletonparams.remove('QUOTED-PRINTABLE')
         if qp:
-            self.value = codecs.decode(self.value.encode("utf-8"), "quoted-printable").decode(self.params['ENCODING'])
+            self.value = quopri.decodestring(self.value).decode('utf-8')
 
     @classmethod
     def duplicate(clz, copyit):

--- a/vobject/icalendar.py
+++ b/vobject/icalendar.py
@@ -8,6 +8,7 @@ import logging
 import random  # for generating a UID
 import socket
 import string
+import base64
 
 from dateutil import rrule, tz
 import six
@@ -633,7 +634,7 @@ class TextBehavior(behavior.Behavior):
         if line.encoded:
             encoding = getattr(line, 'encoding_param', None)
             if encoding and encoding.upper() == cls.base64string:
-                line.value = codecs.decode(self.value.encode("utf-8"), "base64").decode(encoding)
+                line.value = base64.b64decode(line.value)
             else:
                 line.value = stringToTextValues(line.value)[0]
             line.encoded=False
@@ -646,7 +647,7 @@ class TextBehavior(behavior.Behavior):
         if not line.encoded:
             encoding = getattr(line, 'encoding_param', None)
             if encoding and encoding.upper() == cls.base64string:
-                line.value = codecs.encode(self.value.encode(encoding), "base64").decode("utf-8")
+                line.value = base64.b64encode(line.value.encode('utf-8')).decode('utf-8').replace('\n', '')
             else:
                 line.value = backslashEscape(str_(line.value))
             line.encoded=True

--- a/vobject/vcard.py
+++ b/vobject/vcard.py
@@ -1,6 +1,6 @@
 """Definitions and behavior for vCard 3.0"""
 
-import codecs
+import base64
 
 from . import behavior
 
@@ -136,7 +136,7 @@ class VCardTextBehavior(behavior.Behavior):
                 line.encoding_param = cls.base64string
             encoding = getattr(line, 'encoding_param', None)
             if encoding:
-                line.value = codecs.decode(line.value.encode("utf-8"), "base64")
+                line.value = base64.b64decode(line.value)
             else:
                 line.value = stringToTextValues(line.value)[0]
             line.encoded=False
@@ -149,7 +149,7 @@ class VCardTextBehavior(behavior.Behavior):
         if not line.encoded:
             encoding = getattr(line, 'encoding_param', None)
             if encoding and encoding.upper() == cls.base64string:
-                line.value = codecs.encode(line.value.encode(coding), "base64").decode("utf-8")
+                line.value = base64.b64encode(line.value.encode('utf-8')).decode('utf-8').replace('\n', '')
             else:
                 line.value = backslashEscape(line.value)
             line.encoded=True


### PR DESCRIPTION
…and python3)"

This reverts commit 53fb3178be1b7359844b07b50a6f5ad4577af1ea, which
introduces various encoding-related bugs. (#40, #39)
