### PR TITLE
Fix exdate not in rruleset in python 3

### DIFF
--- a/vobject/icalendar.py
+++ b/vobject/icalendar.py
@@ -412,7 +412,7 @@ class RecurringComponent(Component):
 
                 if name in DATENAMES:
                     if type(line.value[0]) == datetime.datetime:
-                        map(addfunc, line.value)
+                        list(map(addfunc, line.value))
                     elif type(line.value[0]) == datetime.date:
                         for dt in line.value:
                             addfunc(datetime.datetime(dt.year, dt.month, dt.day))


### PR DESCRIPTION
As you surely know, `map` does nothing in python3 unless it is iterated.
This causes exdate as a datetime to not be put in the rruleset.
