### PR TITLE
replace deepcopy with copy because of strange error "can't pickle gen…

### DIFF
--- a/vobject/base.py
+++ b/vobject/base.py
@@ -180,7 +180,7 @@ class VBase(object):
         if self.isNative or not self.behavior or not self.behavior.hasNative:
             return self
         else:
-            self_orig = copy.deepcopy(self)
+            self_orig = copy.copy(self)
             try:
                 return self.behavior.transformToNative(self)
             except Exception as e:


### PR DESCRIPTION
Looks like I've used the wrong copy method in my original pull request, causing big problems now on reading valid ICS files:

-> please apply this fix asap and rebase 0.9.4 if possible.

Sorry for that, please also extend selftesting capabilities by using e.g. code from
https://github.com/pbiering/Radicale/blob/pbiering-testing/radicale-storage-check.py
and feed one VCARD and one ICS into.

```
  File "/path/to/radicale-storage-check.py", line 48, in <module>
    item_ser = item.serialize()
  File "/usr/lib/python3.4/site-packages/vobject/base.py", line 254, in serialize
    return behavior.serialize(self, buf, lineLength, validate)
  File "/usr/lib/python3.4/site-packages/vobject/behavior.py", line 166, in serialize
    out = base.defaultSerialize(transformed, buf, lineLength)
  File "/usr/lib/python3.4/site-packages/vobject/base.py", line 1002, in defaultSerialize
    child.serialize(outbuf, lineLength, validate=False)
  File "/usr/lib/python3.4/site-packages/vobject/base.py", line 254, in serialize
    return behavior.serialize(self, buf, lineLength, validate)
  File "/usr/lib/python3.4/site-packages/vobject/behavior.py", line 168, in serialize
    obj.transformToNative()
  File "/usr/lib/python3.4/site-packages/vobject/base.py", line 183, in transformToNative
    self_orig = copy.deepcopy(self)
  File "/usr/lib64/python3.4/copy.py", line 182, in deepcopy
    y = _reconstruct(x, rv, 1, memo)
  File "/usr/lib64/python3.4/copy.py", line 300, in _reconstruct
    state = deepcopy(state, memo)
  File "/usr/lib64/python3.4/copy.py", line 155, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python3.4/copy.py", line 246, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib64/python3.4/copy.py", line 155, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python3.4/copy.py", line 246, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib64/python3.4/copy.py", line 155, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python3.4/copy.py", line 219, in _deepcopy_list
    y.append(deepcopy(a, memo))
  File "/usr/lib64/python3.4/copy.py", line 182, in deepcopy
    y = _reconstruct(x, rv, 1, memo)
  File "/usr/lib64/python3.4/copy.py", line 300, in _reconstruct
    state = deepcopy(state, memo)
  File "/usr/lib64/python3.4/copy.py", line 155, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python3.4/copy.py", line 246, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib64/python3.4/copy.py", line 182, in deepcopy
    y = _reconstruct(x, rv, 1, memo)
  File "/usr/lib64/python3.4/copy.py", line 294, in _reconstruct
    args = deepcopy(args, memo)
  File "/usr/lib64/python3.4/copy.py", line 155, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python3.4/copy.py", line 226, in _deepcopy_tuple
    y.append(deepcopy(a, memo))
  File "/usr/lib64/python3.4/copy.py", line 182, in deepcopy
    y = _reconstruct(x, rv, 1, memo)
  File "/usr/lib64/python3.4/copy.py", line 300, in _reconstruct
    state = deepcopy(state, memo)
  File "/usr/lib64/python3.4/copy.py", line 155, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python3.4/copy.py", line 246, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib64/python3.4/copy.py", line 155, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python3.4/copy.py", line 219, in _deepcopy_list
    y.append(deepcopy(a, memo))
  File "/usr/lib64/python3.4/copy.py", line 182, in deepcopy
    y = _reconstruct(x, rv, 1, memo)
  File "/usr/lib64/python3.4/copy.py", line 300, in _reconstruct
    state = deepcopy(state, memo)
  File "/usr/lib64/python3.4/copy.py", line 155, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python3.4/copy.py", line 246, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib64/python3.4/copy.py", line 182, in deepcopy
    y = _reconstruct(x, rv, 1, memo)
  File "/usr/lib64/python3.4/copy.py", line 300, in _reconstruct
    state = deepcopy(state, memo)
  File "/usr/lib64/python3.4/copy.py", line 155, in deepcopy
    y = copier(x, memo)
  File "/usr/lib64/python3.4/copy.py", line 246, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
  File "/usr/lib64/python3.4/copy.py", line 174, in deepcopy
    rv = reductor(2)
TypeError: can't pickle generator objects
```