### PR TITLE
Changed max parameter (from None to 1) of 'ORG' knownchild in vCard dict

### DIFF
--- a/vobject/vcard.py
+++ b/vobject/vcard.py
@@ -184,7 +184,7 @@ class VCard3_0(VCardBehavior):
         'LABEL':      (0, None, None),
         'UID':        (0, None, None),
         'ADR':        (0, None, None),
-        'ORG':        (0, None, None),
+        'ORG':        (0, 1, None),
         'PHOTO':      (0, None, None),
         'CATEGORIES': (0, None, None)
     }


### PR DESCRIPTION
This solved issue #64  "j.add('org') creates a list object instead of a
string"


I'm not sure if the max parameter set to 'none' was meant to be that we,
but it solved the problem for me.