### PR TITLE
replace file constructors with context managers for python 3 compatibility

### DIFF
--- a/vobject/change_tz.py
+++ b/vobject/change_tz.py
@@ -66,7 +66,8 @@ def main():
 
         with open(out_name, 'wb') as out:
             cal.serialize(out)
-            print("Done")
+
+        print("Done")
 
 
 version = "0.1"

--- a/vobject/change_tz.py
+++ b/vobject/change_tz.py
@@ -64,9 +64,9 @@ def main():
         out_name = ics_file + '.converted'
         print("... Writing {0!s}".format(out_name))
 
-        out = file(out_name, 'wb')
-        cal.serialize(out)
-        print("Done")
+        with open(out_name, 'wb') as out:
+            cal.serialize(out)
+            print("Done")
 
 
 version = "0.1"

--- a/vobject/ics_diff.py
+++ b/vobject/ics_diff.py
@@ -191,11 +191,12 @@ def main():
     if args:
         ignore_dtstamp = options.ignore
         ics_file1, ics_file2 = args
-        cal1 = readOne(file(ics_file1))
-        cal2 = readOne(file(ics_file2))
-        deleteExtraneous(cal1, ignore_dtstamp=ignore_dtstamp)
-        deleteExtraneous(cal2, ignore_dtstamp=ignore_dtstamp)
-        prettyDiff(cal1, cal2)
+        with open(ics_file1) as f, open(ics_file2) as g:
+            cal1 = readOne(f)
+            cal2 = readOne(g)
+            deleteExtraneous(cal1, ignore_dtstamp=ignore_dtstamp)
+            deleteExtraneous(cal2, ignore_dtstamp=ignore_dtstamp)
+            prettyDiff(cal1, cal2)
 
 version = "0.1"
 

--- a/vobject/ics_diff.py
+++ b/vobject/ics_diff.py
@@ -194,9 +194,9 @@ def main():
         with open(ics_file1) as f, open(ics_file2) as g:
             cal1 = readOne(f)
             cal2 = readOne(g)
-            deleteExtraneous(cal1, ignore_dtstamp=ignore_dtstamp)
-            deleteExtraneous(cal2, ignore_dtstamp=ignore_dtstamp)
-            prettyDiff(cal1, cal2)
+        deleteExtraneous(cal1, ignore_dtstamp=ignore_dtstamp)
+        deleteExtraneous(cal2, ignore_dtstamp=ignore_dtstamp)
+        prettyDiff(cal1, cal2)
 
 version = "0.1"
 


### PR DESCRIPTION
`file()` was removed in Python 3 - replace all calls with `open()` and use with statements for closing. Resolves #66 