### PR TITLE
fix some getrruleset() bugs

### DIFF
--- a/vobject/icalendar.py
+++ b/vobject/icalendar.py
@@ -417,7 +417,7 @@ class RecurringComponent(Component):
 
                 if name in DATENAMES:
                     if type(line.value[0]) == datetime.datetime:
-                        map(addfunc, line.value)
+                        list(map(addfunc, line.value))
                     elif type(line.value[0]) == datetime.date:
                         for dt in line.value:
                             addfunc(datetime.datetime(dt.year, dt.month, dt.day))


### PR DESCRIPTION
- make python 3 compatible by iterating over the map
- add `DTSTART` to the output of `getrruleset(addRDate=True)`  if there's an `RDATE` prop but no `RRULE`

resolves #83 