### PR TITLE
Fix parsing objects with non-base64 encoding

### DIFF
--- a/vobject/vcard.py
+++ b/vobject/vcard.py
@@ -136,7 +136,7 @@ class VCardTextBehavior(behavior.Behavior):
                 line.singletonparams.remove('BASE64')
                 line.encoding_param = cls.base64string
             encoding = getattr(line, 'encoding_param', None)
-            if encoding:
+            if encoding and "base64" in encoding.lower():
                 if isinstance(line.value, bytes):
                     line.value = codecs.decode(line.value, "base64")
                 else:


### PR DESCRIPTION
When a field has an encoding specification, but that encoding
specification is not Base64, do not try to Base64-decode the field.

Fixes #100.