### PR TITLE
Fix formatter of auto-installed logging handler.

### DIFF
--- a/vobject/base.py
+++ b/vobject/base.py
@@ -69,7 +69,7 @@ def to_basestring(s):
 logger = logging.getLogger(__name__)
 if not logging.getLogger().handlers:
     handler = logging.StreamHandler()
-    formatter = logging.Formatter('{name} {levelname} {message}')
+    formatter = logging.Formatter('%(name)s %(levelname)s %(message)s')
     handler.setFormatter(formatter)
     logger.addHandler(handler)
 logger.setLevel(logging.ERROR)  # Log errors


### PR DESCRIPTION
Formatter objects in Python 3.2+ support .format()-style format strings
if constructed with the style parameter set to '{', but that was never
backported to Python 2.7.