### PR TITLE
rrule-ignoretz-fix and comments about dateutil.rrule >= 2.7.1 until handling.

### DIFF
--- a/vobject/icalendar.py
+++ b/vobject/icalendar.py
@@ -449,7 +449,10 @@ class RecurringComponent(Component):
                         value, dtstart=dtstart,
                         # If dtstart has no time zone, `until`
                         # shouldn't get one, either:
-                        ignoretz=isinstance(dtstart, datetime.date))
+                        ignoretz=(
+                            isinstance(dtstart, datetime.date) and
+                            not isinstance(dtstart, datetime.datetime)
+                            ))
                     until = rule._until
 
                     if until is not None and isinstance(dtstart,

--- a/vobject/icalendar.py
+++ b/vobject/icalendar.py
@@ -452,7 +452,7 @@ class RecurringComponent(Component):
                     ignoretz = (
                         isinstance(dtstart, datetime.date) and
                         not isinstance(dtstart, datetime.datetime))
-                    # dateutil.rrule >= 2.7.0 now includes the following check:
+                    # dateutil.rrule >= 2.7.1 now includes the following check:
                     #
                     # According to RFC5545 Section 3.3.10:
                     # https://tools.ietf.org/html/rfc5545#section-3.3.10
@@ -467,12 +467,12 @@ class RecurringComponent(Component):
                     #)
                     #
                     # Previously UNTIL was handled below after creating
-                    # the rule. Now dateutil.rrule >= 2.7.0 fails to create the
+                    # the rule. Now dateutil.rrule >= 2.7.1 fails to create the
                     # rule if the UNTIL part does not pass the above test. This
                     # causes TestIcalendar.test_recurrence to fail because the
                     # rule never gets created. It is unclear what the best
                     # approach is to handle UNTIL and TestIcalendar.test_recurrence
-                    # in light of dateutil.rrule >= 2.7.0 internally forcing
+                    # in light of dateutil.rrule >= 2.7.1 internally forcing
                     # compliance with RFC5545 Section 3.3.10.
                     rule = rrule.rrulestr(
                         value, dtstart=dtstart,

--- a/vobject/icalendar.py
+++ b/vobject/icalendar.py
@@ -445,14 +445,38 @@ class RecurringComponent(Component):
                     # a Ruby iCalendar library escapes semi-colons in rrules,
                     # so also remove any backslashes
                     value = line.value.replace('\\', '')
+                    # If dtstart has no time zone, `until` shouldn't have one.
+                    # Note: isinstance(dtstart, datetime.date) is not sufficient
+                    # to check for date only because isinstance(datetime.datetime,
+                    # datetime.date) == True.
+                    ignoretz = (
+                        isinstance(dtstart, datetime.date) and
+                        not isinstance(dtstart, datetime.datetime))
+                    # dateutil.rrule >= 2.7.0 now includes the following check:
+                    #
+                    # According to RFC5545 Section 3.3.10:
+                    # https://tools.ietf.org/html/rfc5545#section-3.3.10
+                    #
+                    # > If the "DTSTART" property is specified as a date with UTC
+                    # > time or a date with local time and time zone reference,
+                    # > then the UNTIL rule part MUST be specified as a date with
+                    # > UTC time.
+                    #raise ValueError(
+                    #'RRULE UNTIL values must be specified in UTC when DTSTART '
+                    #'is timezone-aware'
+                    #)
+                    #
+                    # Previously UNTIL was handled below after creating
+                    # the rule. Now dateutil.rrule >= 2.7.0 fails to create the
+                    # rule if the UNTIL part does not pass the above test. This
+                    # causes TestIcalendar.test_recurrence to fail because the
+                    # rule never gets created. It is unclear what the best
+                    # approach is to handle UNTIL and TestIcalendar.test_recurrence
+                    # in light of dateutil.rrule >= 2.7.0 internally forcing
+                    # compliance with RFC5545 Section 3.3.10.
                     rule = rrule.rrulestr(
                         value, dtstart=dtstart,
-                        # If dtstart has no time zone, `until`
-                        # shouldn't get one, either:
-                        ignoretz=(
-                            isinstance(dtstart, datetime.date) and
-                            not isinstance(dtstart, datetime.datetime)
-                            ))
+                        ignoretz=ignoretz)
                     until = rule._until
 
                     if until is not None and isinstance(dtstart,


### PR DESCRIPTION
This pull request is intended to fix icalendar.RecurringComponent.getrruleset ignoring the timezone if dtstart is only a date. The previous check isinstance(dtstart, datetime.date) is not sufficient to check for date only because isinstance(datetime.datetime, datetime.date) == True which ignores the timezone for datetimes as well.

It also includes comments regarding dateutil.rrule >= 2.7.1 internally checking UNTIL clauses and breaking TestIcalendar.test_recurrence. icalendar.RecurringComponent.getrruleset is also trying to handle UNTIL clauses, but AFTER the rule is created. It is unclear what if anything should be done (handle UNTIL before the rule is created or rely on dateutil and update TestIcalendar.test_recurrence.