### PR TITLE
ignore escaped semi-colons in UNTIL value

### DIFF
--- a/vobject/icalendar.py
+++ b/vobject/icalendar.py
@@ -458,7 +458,7 @@ class RecurringComponent(Component):
                         # dateutil converts the UNTIL date to a datetime,
                         # check to see if the UNTIL parameter value was a date
                         vals = dict(pair.split('=') for pair in
-                                    line.value.upper().split(';'))
+                                    value.upper().split(';'))
                         if len(vals.get('UNTIL', '')) == 8:
                             until = datetime.datetime.combine(until.date(),
                                                               dtstart.time())


### PR DESCRIPTION
``line.value`` may contain escaped semi-colons (Ruby iCalendar library). This will influence the length of the UNTIL value, if it's not the last parameter.