### PR TITLE
RRULE: Fix floating UNTIL with dateutil > 2.6.1

### DIFF
--- a/vobject/icalendar.py
+++ b/vobject/icalendar.py
@@ -449,7 +449,15 @@ class RecurringComponent(Component):
                     # shouldn't get one, either:
                     ignoretz = (not isinstance(dtstart, datetime.datetime) or
                                 dtstart.tzinfo is None)
-                    until = rrule.rrulestr(value, ignoretz=ignoretz)._until
+                    try:
+                        until = rrule.rrulestr(value, ignoretz=ignoretz)._until
+                    except ValueError:
+                        # WORKAROUND: dateutil<=2.7.2 doesn't set the time zone
+                        # of dtstart
+                        if ignoretz:
+                            raise
+                        utc_now = datetime.datetime.now(datetime.timezone.utc)
+                        until = rrule.rrulestr(value, dtstart=utc_now)._until
 
                     if until is not None and isinstance(dtstart,
                                                         datetime.datetime) and \

--- a/vobject/icalendar.py
+++ b/vobject/icalendar.py
@@ -445,11 +445,7 @@ class RecurringComponent(Component):
                     # a Ruby iCalendar library escapes semi-colons in rrules,
                     # so also remove any backslashes
                     value = line.value.replace('\\', '')
-                    # If dtstart has no time zone, `until`
-                    # shouldn't get one, either:
-                    ignoretz = (not isinstance(dtstart, datetime.datetime) or
-                                dtstart.tzinfo is None)
-                    until = rrule.rrulestr(value, ignoretz=ignoretz)._until
+                    until = rrule.rrulestr(value, ignoretz=True)._until
 
                     if until is not None and isinstance(dtstart,
                                                         datetime.datetime) and \
@@ -491,7 +487,7 @@ class RecurringComponent(Component):
                         pair for pair in value.split(';')
                         if pair.split('=')[0].upper() != 'UNTIL')
                     rule = rrule.rrulestr(value_without_until,
-                                          dtstart=dtstart, ignoretz=ignoretz)
+                                          dtstart=dtstart, ignoretz=True)
                     rule._until = until
 
                     # add the rrule or exrule to the rruleset

--- a/vobject/icalendar.py
+++ b/vobject/icalendar.py
@@ -445,7 +445,11 @@ class RecurringComponent(Component):
                     # a Ruby iCalendar library escapes semi-colons in rrules,
                     # so also remove any backslashes
                     value = line.value.replace('\\', '')
-                    until = rrule.rrulestr(value, ignoretz=True)._until
+                    # If dtstart has no time zone, `until`
+                    # shouldn't get one, either:
+                    ignoretz = (not isinstance(dtstart, datetime.datetime) or
+                                dtstart.tzinfo is None)
+                    until = rrule.rrulestr(value, ignoretz=ignoretz)._until
 
                     if until is not None and isinstance(dtstart,
                                                         datetime.datetime) and \
@@ -487,7 +491,7 @@ class RecurringComponent(Component):
                         pair for pair in value.split(';')
                         if pair.split('=')[0].upper() != 'UNTIL')
                     rule = rrule.rrulestr(value_without_until,
-                                          dtstart=dtstart, ignoretz=True)
+                                          dtstart=dtstart, ignoretz=ignoretz)
                     rule._until = until
 
                     # add the rrule or exrule to the rruleset


### PR DESCRIPTION
Fixes #113, #112 

dateutil > 2.6.1 raises an exception when UNTIL is floating and DTSTART is not. This PR fixes the issue by parsing the RRULE first without DTSTART to extract the UNTIL parameter and then without the UNTIL parameter but with DTSTART. The RRULE without UNTIL and the normalized UNTIL are combined at the end.

This PR makes #111 obsolete.