### PR TITLE
Fixed regexp for VCF Version 2.1

### DIFF
--- a/vobject/base.py
+++ b/vobject/base.py
@@ -774,7 +774,7 @@ patterns['params_grouped'] = r"""
 # get a full content line, break it up into group, name, parameters, and value
 patterns['line'] = r"""
 ^ ((?P<group> {name!s})\.)?(?P<name> {name!s}) # name group
-  (?P<params> (?: {param!s} )* )               # params group (may be empty)
+  (?P<params> ;?(?: {param!s} )* )               # params group (may be empty)
 : (?P<value> .* )$                             # value group
 """.format(**patterns)
 


### PR DESCRIPTION
That small changes doesn't break any current logic for versions 3.0+ but it provides to work with older versions.