### PR TITLE
repr changed for datetime.timedelta in python 3.7

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -253,7 +253,7 @@ class TestBehaviors(unittest.TestCase):
         )
         self.assertEqual(
             str(parseRDate(textLineToContentLine("RDATE;VALUE=PERIOD:19960403T020000Z/19960403T040000Z,19960404T010000Z/PT3H"))),
-            "<RDATE{'VALUE': ['PERIOD']}[(datetime.datetime(1996, 4, 3, 2, 0, tzinfo=tzutc()), datetime.datetime(1996, 4, 3, 4, 0, tzinfo=tzutc())), (datetime.datetime(1996, 4, 4, 1, 0, tzinfo=tzutc()), datetime.timedelta(0, 10800))]>"
+            "<RDATE{'VALUE': ['PERIOD']}[(datetime.datetime(1996, 4, 3, 2, 0, tzinfo=tzutc()), datetime.datetime(1996, 4, 3, 4, 0, tzinfo=tzutc())), (datetime.datetime(1996, 4, 4, 1, 0, tzinfo=tzutc()), " + ("datetime.timedelta(0, 10800)" if sys.version_info < (3,7) else "datetime.timedelta(seconds=10800)") + ")]>"
         )
 
     def test_periodBehavior(self):


### PR DESCRIPTION
Update the expected string to deal with both old and new repr for datetime.timedelta.

see https://docs.python.org/3.7/whatsnew/3.7.html#changes-in-the-python-api