### PR TITLE
Add reading multiple vCards to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,3 +275,9 @@ u'Harris'
 [<EMAIL{'TYPE': ['INTERNET']}jeffrey@osafoundation.org>,
  <EMAIL{'TYPE': ['INTERNET']}jeffery@example.org>]
 ```
+
+Just like with iCalendar example above readComponents will yield a generator from a stream or string containing multiple vCards objects.
+```
+>>> vobject.readComponents(vCardStream).next().email.value
+'jeffrey@osafoundation.org'
+```


### PR DESCRIPTION
Originally when using this package I missed that you could use readComponents to read a stream of vCards not just iCalendar objects. This just adds a quick mention that this works with both under the vCard section in the readme.