### PR TITLE
ensure BYDAY is present in VTIMEZONEs RRULE (fixes #151)

### DIFF
--- a/vobject/icalendar.py
+++ b/vobject/icalendar.py
@@ -298,7 +298,7 @@ class TimezoneComponent(Component):
                 if num is not None:
                     dayString = ";BYDAY=" + str(num) + WEEKDAYS[rule['weekday']]
                 else:
-                    dayString = ""
+                    dayString = ";BYDAY=1"
                 if rule['end'] is not None:
                     if rule['hour'] is None:
                         # all year offset, with no rule


### PR DESCRIPTION
This PR resolves and implements fix suggested in #151. 

[More info](https://support.microsoft.com/en-us/topic/outlook-receives-a-message-that-has-an-attachment-that-is-named-not-supported-calendar-message-ics-e4452c5a-2b0d-767f-fb89-ca1acfaaee9c) about Microsoft Outlook unsupporting some recurrence patterns.

