### PR TITLE
Import `basestring` from `.base`

### DIFF
--- a/vobject/vcard.py
+++ b/vobject/vcard.py
@@ -4,15 +4,9 @@ import codecs
 
 from . import behavior
 
-from .base import ContentLine, registerBehavior, backslashEscape, str_
+from .base import ContentLine, registerBehavior, backslashEscape, basestring, str_
 from .icalendar import stringToTextValues
 
-
-# Python 3 no longer has a basestring type, so....
-try:
-    basestring = basestring
-except NameError:
-    basestring = (str, bytes)
 
 # ------------------------ vCard structs ---------------------------------------
 


### PR DESCRIPTION
It is defined here: https://github.com/eventable/vobject/blob/498555a553155ea9b26aace93332ae79365ecb31/vobject/base.py#L13-L17