### PR TITLE
Fix win32tz.py on python 3

### DIFF
--- a/vobject/win32tz.py
+++ b/vobject/win32tz.py
@@ -1,4 +1,8 @@
-import _winreg
+import sys
+if sys.version_info[0] >= 3:
+    import winreg as _winreg
+else:
+    import _winreg
 import struct
 import datetime
 


### PR DESCRIPTION
This is due to a bad import. `_win32reg` is now `win32reg`