### PR TITLE
fix diff when one calendar is empty

### DIFF
--- a/vobject/ics_diff.py
+++ b/vobject/ics_diff.py
@@ -91,7 +91,11 @@ def diff(left, right):
                     matchResult = processComponentPair(comp, rightComp)
                     if matchResult is not None:
                         output.append(matchResult)
-
+                        
+        while rightIndex < rightListSize:
+            output.append((None, rightList[rightIndex]))
+            rightIndex += 1
+            
         return output
 
     def newComponent(name, body):


### PR DESCRIPTION
When leftList is empty, no diff results are returned even if rightList contains items. This pull request fixes this.