### PR TITLE
Allow additional arguments to be passed through serialize()

### DIFF
--- a/vobject/base.py
+++ b/vobject/base.py
@@ -239,7 +239,7 @@ class VBase(object):
         """
         pass
 
-    def serialize(self, buf=None, lineLength=75, validate=True, behavior=None):
+    def serialize(self, buf=None, lineLength=75, validate=True, behavior=None, *args, **kwargs):
         """
         Serialize to buf if it exists, otherwise return a string.
 
@@ -251,7 +251,7 @@ class VBase(object):
         if behavior:
             if DEBUG:
                 logger.debug("serializing {0!s} with behavior {1!s}".format(self.name, behavior))
-            return behavior.serialize(self, buf, lineLength, validate)
+            return behavior.serialize(self, buf, lineLength, validate, *args, **kwargs)
         else:
             if DEBUG:
                 logger.debug("serializing {0!s} without behavior".format(self.name))

--- a/vobject/behavior.py
+++ b/vobject/behavior.py
@@ -141,7 +141,7 @@ class Behavior(object):
         pass
 
     @classmethod
-    def serialize(cls, obj, buf, lineLength, validate=True):
+    def serialize(cls, obj, buf, lineLength, validate=True, *args, **kwargs):
         """
         Set implicit parameters, do encoding, return unicode string.
 

--- a/vobject/vcard.py
+++ b/vobject/vcard.py
@@ -226,7 +226,7 @@ class Photo(VCardTextBehavior):
         return " (BINARY PHOTO DATA at 0x{0!s}) ".format(id(line.value))
 
     @classmethod
-    def serialize(cls, obj, buf, lineLength, validate):
+    def serialize(cls, obj, buf, lineLength, validate,  *args, **kwargs):
         """
         Apple's Address Book is *really* weird with images, it expects
         base64 data to have very specific whitespace.  It seems Address Book
@@ -234,8 +234,7 @@ class Photo(VCardTextBehavior):
         """
         if wacky_apple_photo_serialize:
             lineLength = REALLY_LARGE
-        VCardTextBehavior.serialize(obj, buf, lineLength, validate)
-
+        VCardTextBehavior.serialize(obj, buf, lineLength, validate, *args, **kwargs)
 registerBehavior(Photo)
 
 


### PR DESCRIPTION
When a derived class needs additional arguments to the serialize() method, the base class should just pass those unknown arguments to the derived behavior.

An example use case is where someone wants to filter the objects that are serialized.